### PR TITLE
don't create a fake build.json

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ matrix:
       #    - yes | sdkmanager "platforms;android-27"
     - yes | sdkmanager tools > /dev/null
     - yes | sdkmanager --licenses > /dev/null
-    - echo {} > cordova-app/build.json
+#   - echo {} > cordova-app/build.json -- build.json gets decrypted by travis and is required, so don't create a fake one for local runs
     - if [ "$TRAVIS_PULL_REQUEST" == false ]; then openssl aes-256-cbc -K $encrypted_24a643539195_key
       -iv $encrypted_24a643539195_iv -in cordova-app/secrets.tar.enc -out cordova-app/secrets.tar
       -d && cd cordova-app && tar xvf secrets.tar && cd ..; fi
@@ -144,7 +144,7 @@ matrix:
       - node_modules/
     before_install:
     - nvm install 13
-    - echo {} > cordova-app/build.json
+#   - echo {} > cordova-app/build.json -- build.json gets decrypted by travis and is required, so don't create a fake one for local runs
     - if [ "$TRAVIS_PULL_REQUEST" == false ]; then openssl aes-256-cbc -K $encrypted_24a643539195_key
       -iv $encrypted_24a643539195_iv -in cordova-app/secrets.tar.enc -out cordova-app/secrets.tar
       -d && cd cordova-app && tar xvf secrets.tar && cd ..; fi


### PR DESCRIPTION
build.json gets expanded during the travis run to contain the correct settings, without these settings we see mysterious errors like "Signing for "Plastic Patrol" requires a development team." which is a red herring. So if we're not in the correct environment (ie travis), these builds will fail, so let's just fail early.